### PR TITLE
Updated vulnerable Tenda FH456 router firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The contents of this repo include:
 - Tenda AC8 V2.0
 - Tenda AC10 V3
 - Tenda AC11 V2.0
-- Tenda FH456 V2.0
+- Tenda FH456 V4.0
 - Zyxel NBG6615 V1.00
 - Intelbras RF 301K V1.1.15
 - Multilaser AC1200 RE018
@@ -50,3 +50,6 @@ If you find a new vulnerable device, please submit a pull request.
 - Octavio Galland (@GallandOctavio)
 - Javier Aguinaga (@pastaCLS)
 - Emilio Couto (@ekio_jp)
+
+## Corrections:
+- @munchkindev


### PR DESCRIPTION
As notified in Issue #2 this information was corrected.